### PR TITLE
Always include 'content-type' header

### DIFF
--- a/view/xsendfile.php
+++ b/view/xsendfile.php
@@ -43,9 +43,7 @@ if (file_exists($path)) {
         //error_log("X-Sendfile: {$path}");
         header("X-Sendfile: {$path}");
     }
-    if (empty($_GET['download'])) {
-        header("Content-type: " . mime_content_type($path));
-    }
+    header("Content-type: " . mime_content_type($path));
     header('Content-Length: ' . filesize($path));
     if (!empty($advancedCustom->doNotUseXsendFile)) {
         echo url_get_contents($path);


### PR DESCRIPTION
Without this each download is marked a 'text/html', and downloaded as such. On my Mac that's not a problem, but when I download a file on an Android tablet, the resulting file is marked as a HTML file instead of as a video - and opening it will display a bunch of gibberish unicode instead of the video. This change includes the mime-type in each response, since (as far as I'm aware) there are no downsides to doing that.